### PR TITLE
Implement assets repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+max_line_length = 128
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,14 @@
+name: Release
+
+on:
+  push: {}
+  pull_request: {}
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - env:
+          RELEASES_API_KEY: ${{ secrets.RELEASES_API_KEY }}
+        run: ./release.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# OS and editors
+.DS_Store
+._*
+Thumbs.db
+Desktop.ini
+*.bak
+.cache
+.project
+.settings
+.tmproj
+nbproject
+*.sublime-project
+*.sublime-workspace
+.idea

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+streamlink-assets
+====
+
+Release asset repository for [Streamlink](https://github.com/streamlink/streamlink).
+
+The files can be found on the repo's [releases](https://github.com/streamlink/streamlink-assets/releases) page.

--- a/data.json
+++ b/data.json
@@ -1,0 +1,36 @@
+[
+    {
+        "url": "https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-4.2.2-win32-static.zip",
+        "checksum": "1f6adff50db6cad54fdab15013c4c95cb6f83d7fe6d1167f3896cf4550573565",
+        "filename": "ffmpeg-4.2.2-win32-static.zip",
+        "sourcedir": "ffmpeg-4.2.2-win32-static",
+        "targetdir": "ffmpeg",
+        "files": [
+            {
+                "from": "bin/ffmpeg.exe",
+                "to": "ffmpeg.exe"
+            },
+            {
+                "from": "LICENSE.txt",
+                "to": "LICENSE.txt"
+            }
+        ]
+    },
+    {
+        "url": "https://rtmpdump.mplayerhq.hu/download/rtmpdump-2.3-windows.zip",
+        "checksum": "6948aa372f04952d5675917c6ca2c7c0bf6b109de21a4323adc93247fff0189f",
+        "filename": "rtmpdump-2.3-windows.zip",
+        "sourcedir": "rtmpdump-2.3",
+        "targetdir": "rtmpdump",
+        "files": [
+            {
+                "from": "rtmpdump.exe",
+                "to": "rtmpdump.exe"
+            },
+            {
+                "from": "COPYING",
+                "to": "LICENSE.txt"
+            }
+        ]
+    }
+]

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -e
+
+for var in GITHUB_ACTIONS GITHUB_REPOSITORY; do
+    [[ -z "${!var}" ]] && { echo >&2 "Missing ${var} env var"; exit 1; }
+done
+
+DATA="data.json"
+FILES=()
+
+GITHUB_API_URL="https://api.github.com/repos/${GITHUB_REPOSITORY}"
+GITHUB_API_HEADERS=(
+    -H "Accept: application/vnd.github.v3+json"
+    -H "User-Agent: ${GITHUB_REPOSITORY}"
+    -H "Authorization: token ${RELEASES_API_KEY}"
+)
+
+
+ROOT="$(git rev-parse --show-toplevel)"
+TEMP=$(mktemp -d) && trap "rm -rf ${TEMP}" EXIT || exit 255
+cd "${TEMP}"
+
+
+while IFS=" " read -r url checksum filename; do
+    echo "Downloading ${filename}"
+    curl -s -L --output "${filename}" "${url}"
+    echo "Comparing checksums"
+    echo "${checksum} ${filename}" | sha256sum --check -
+    FILES+=("${filename}")
+done < <(jq -r '.[] | "\(.url) \(.checksum) \(.filename)"' "${ROOT}/${DATA}")
+
+
+[[ "${GITHUB_REF}" =~ ^refs/tags/.+ ]] || { echo -e "Not a release, aborting\n\nDone"; exit 0; }
+[[ -z "${RELEASES_API_KEY}" ]] && { echo >&2 "Missing RELEASES_API_KEY env var"; exit 1; }
+
+
+TAG_NAME="${GITHUB_REF#refs/tags/}"
+
+echo "Checking for existing release on tag: ${TAG_NAME}"
+RELEASE_ID=$(curl -s \
+    -X GET \
+    "${GITHUB_API_HEADERS[@]}" \
+    "${GITHUB_API_URL}/releases/tags/${TAG_NAME}" \
+    | jq -r ".id | select(. != null)"
+)
+
+if [[ -n "${RELEASE_ID}" ]]; then
+    echo "Release found: ${RELEASE_ID}"
+else
+    RELEASE_ID=$(curl -s \
+        -X POST \
+        "${GITHUB_API_HEADERS[@]}" \
+        -d "{\"tag_name\":\"${TAG_NAME}\",\"name\":\"${TAG_NAME}\"}" \
+        "${GITHUB_API_URL}/releases" \
+        | jq -r ".id | select(. != null)"
+    )
+    if [[ -z "${RELEASE_ID}" ]]; then
+        echo >&2 "Could not create new release"
+        exit 1
+    fi
+    echo "New release created: ${RELEASE_ID}"
+fi
+
+for file in "${FILES[@]}"; do
+    echo "Uploading release asset: ${file}"
+    curl -s \
+        -X POST \
+        "${GITHUB_API_HEADERS[@]}" \
+        -H "Content-Type: application/octet-stream" \
+        -H "Content-Length: $(stat --printf="%s" "${file}")" \
+        --data-binary "@${file}" \
+        "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${file}" \
+        > /dev/null
+done
+
+
+echo -e "\nDone"


### PR DESCRIPTION
/cc @beardypig @back-to @gravyboat 

Implements a release workflow and assets config according to
https://github.com/streamlink/streamlink/issues/2872

Defines the list of assets in `data.json` with checksums and a list of files that will be extracted by the makeinstaller.sh script in the streamlink/streamlink repo.

Currently included assets (prebuilt):
- `ffmpeg-4.2.2-win32-static.zip` from the zeranoe builds
  https://ffmpeg.zeranoe.com/builds/
- `rtmpdump-2.3-windows.zip` from the official rtmpdump site
  https://rtmpdump.mplayerhq.hu/

Updated makeinstaller.sh script (will open a PR once this has been merge here):
https://github.com/streamlink/streamlink/compare/master...bastimeyer:installer/external-assets

Test release on my test account:
- Release:
  https://github.com/bastimeyer-test/streamlink-assets-test/releases/tag/2020.4.15
- Regular push (verifies checksums):
  https://github.com/bastimeyer-test/streamlink-assets-test/runs/589908213?check_suite_focus=true#step:3:1
- Tag push (uploads assets to a new or existing release):
  https://github.com/bastimeyer-test/streamlink-assets-test/runs/589910598?check_suite_focus=true#step:3:1

----

Not sure how important it is and whether it's even possible on Github actions due to build time limitations, but building the assets ourselves from source would ideally be better than re-hosting the prebuilt files. Not the topic of this PR though.